### PR TITLE
Allow overriding of vipe#raw_pop function.

### DIFF
--- a/plugin/vipe.vim
+++ b/plugin/vipe.vim
@@ -13,7 +13,7 @@ function! vipe#raw_pop()
   end
 endf
 
-function vipe#raw_push(command)
+function! vipe#raw_push(command)
   if vipe#raw_peek() == 0 || vipe#raw_peek() != a:command
    call insert(s:command_stack, a:command)
   end


### PR DESCRIPTION
To avoid getting an error when either re-sourcing vimscripts that reload vipe or when :BundleInstall from Vundle.
