### PR TITLE
Substitute null bytes with newlines for incoming commands

### DIFF
--- a/vipe
+++ b/vipe
@@ -56,7 +56,7 @@ run_command cached_command if cached_command
 
 File.open pipe_path, 'w+' do |file|
   loop do
-    command = file.gets
+    command = file.gets.gsub(/\000/,"\n")
     run_command(command)
   end
 end


### PR DESCRIPTION
because Vim uses null bytes to represent newlines in multiline strings. I encounter this when passing Vipe [commands from visual selection.](https://github.com/ships/eden/blob/main/assets/vimrc.local#L31)